### PR TITLE
Added descriptive message when repository cannot be rolled back

### DIFF
--- a/cloneRepositories.py
+++ b/cloneRepositories.py
@@ -507,6 +507,9 @@ def main():
         print()
         print(e)
         logging.error(e)
+    except Exception as e: # If anything else happens
+        print(f'ERROR: Something happened. Check {LOG_FILE_PATH}')
+        logging.error(e)
     exit()
 
 

--- a/cloneRepositories.py
+++ b/cloneRepositories.py
@@ -65,16 +65,17 @@ class RepoHandler(Thread):
                 print(f'{LIGHT_RED}Skipping `{self.__repo.name}` because it has 0 commits.{WHITE}')
                 logging.warning(f'Skipping repo `{self.__repo.name}` because it has 0 commits.')
                 return
-
-            self.clone_repo() # clones repo
-            commit_hash = self.get_commit_hash() # get commit hash at due date
             
-            if commit_hash is not None: # commit hash is found at the due date
+            due_date = datetime.strptime(f'{self.__date_due} {self.__time_due}', '%Y-%m-%d %H:%M')
+
+            if due_date > self.__repo.created_at: # clone only if the repo was made before the due date
+                self.clone_repo() # clones repo
+                commit_hash = self.get_commit_hash() # get commit hash at due date
                 self.rollback_repo(commit_hash) # rollback repo to commit hash
                 self.get_repo_stats() # get average lines per commit
             else:
-                print(f'{LIGHT_RED}Cannot rollback repository `{self.__repo.name}` because it was created past the due date (created: {self.__repo.created_at}).{WHITE}')
-                logging.warning(f'Repo `{self.__repo.name}` failed to roll back because it was created past the due date (created: {self.__repo.created_at}).')
+                print(f'{LIGHT_RED}Skipping `{self.__repo.name}` because it was created past the due date (created: {self.__repo.created_at}).{WHITE}')
+                logging.warning(f'Skipping `{self.__repo.name}`  because it was created past the due date (created: {self.__repo.created_at}).')
                 return 
 
         except IndexError as e: # Catch exception raised by get_repo_stats

--- a/cloneRepositories.py
+++ b/cloneRepositories.py
@@ -68,8 +68,15 @@ class RepoHandler(Thread):
 
             self.clone_repo() # clones repo
             commit_hash = self.get_commit_hash() # get commit hash at due date
-            self.rollback_repo(commit_hash) # rollback repo to commit hash
-            self.get_repo_stats() # get average lines per commit
+            
+            if commit_hash is not None: # commit hash is found at the due date
+                self.rollback_repo(commit_hash) # rollback repo to commit hash
+                self.get_repo_stats() # get average lines per commit
+            else:
+                print(f'{LIGHT_RED}Cannot rollback repository `{self.__repo.name}` because it was created past the due date (created: {self.__repo.created_at}).{WHITE}')
+                logging.warning(f'Repo `{self.__repo.name}` failed to roll back because it was created past the due date (created: {self.__repo.created_at}).')
+                return 
+
         except IndexError as e: # Catch exception raised by get_repo_stats
                 print(f'{LIGHT_RED}IndexError while finding average lines per commit for `{self.__repo.name}`.{WHITE}') # Print error to end user
                 logging.warning(f'IndexError while finding average lines per commit for `{self.__repo.name}`.') # log warning to log file
@@ -86,6 +93,7 @@ class RepoHandler(Thread):
         Due to some weird authentication issues. Git clone might need to have the github link with the token passed e.g.
         https://www.<token>@github.com/<organization>/<Repository.name>
         '''
+        
         print(f'Cloning {self.__repo.name} into {self.__repo_path}...') # tell end user what repo is being cloned and where it is going to
         # run process on system that executes 'git clone' command. stdout is redirected so it doesn't output to end user
         clone_process = subprocess.Popen(['git', 'clone', self.__repo.clone_url, f'{str(self.__repo_path)}'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT) # git clone to output file, Hides output from console
@@ -498,9 +506,6 @@ def main():
     except NotImplementedError as e:
         print()
         print(e)
-        logging.error(e)
-    except Exception as e: # If anything else happens
-        print(f'ERROR: Something happened. Check {LOG_FILE_PATH}')
         logging.error(e)
     exit()
 


### PR DESCRIPTION
`commit_hash` variable was returning None when the repo cannot be pulled. 

Input
> Date Due (format = yyyy-mm-dd, press `enter` for current): 2022-01-12
> Time Due (24hr, press `enter` for current): 12:00

Output:
> Cannot rollback repository `unit-01-maxstein16` because it was created past the due date (created: 2022-01-14 00:17:50).
> Cannot rollback repository `unit-01-ds5470` because it was created past the due date (created: 2022-01-21 19:57:47).
> Cannot rollback repository `unit-01-joshcohn27` because it was created past the due date (created: 2022-01-14 19:03:12).

I thought about deleting the repo if it can't be rolled back, but this should be fine